### PR TITLE
cut down on number of rank/select calls

### DIFF
--- a/internal/r_index.hpp
+++ b/internal/r_index.hpp
@@ -602,11 +602,7 @@ private:
 
 		}
 
-		auto t = triple(range, j, k);
-
-		assert(t == old_count_and_get_occ(P));
-
-		return t;
+		return triple(range, j, k);
 	}
 
 	/*

--- a/internal/r_index.hpp
+++ b/internal/r_index.hpp
@@ -536,6 +536,7 @@ private:
 	 * returns <range, j,k>
 	 *
 	 */
+
 	triple count_and_get_occ(string &P){
 
 		//coordinates of an occurrence of current pattern suffix
@@ -543,13 +544,16 @@ private:
 		ulint k = 0;
 
 		range_t range = full_range();
+		range_t prev_range;
 		range_t range1;
 
 		ulint m = P.size();
 
+		uchar c;
+
 		for(ulint i=0;i<m and range.second>=range.first;++i){
 
-			uchar c = P[m-i-1];
+			c = P[m-i-1];
 
 			range1 = LF(range,c);
 
@@ -562,31 +566,47 @@ private:
 
 					assert(j>0);
 
-					//j-1 is an occurrence of the new pattern suffix
 					j = j-1;
 
-					//k is the new SA position corresponding to j
 					k = LF(k);
 
-				}else{
+				}else if (is_unary(range1)) {
 
-					//find a brand new occurrence
 					k = get_sampled_position(range, c); //careful: k is an L-position
+
 					j = k==0 ? 0 : bwt_sample(k);
 
-					//map from L to F column
 					k = LF(k);
 
 				}
 
+			}else{
+
+				return triple(range1, j, k);
+
 			}
+
+			prev_range = range;
 
 			range = range1;
 
 		}
 
-		return triple(range, j, k);
+		if (range != range_t(1,0) && !is_unary(prev_range)) {
 
+			k = get_sampled_position(prev_range, c); //careful: k is an L-position
+
+			j = k==0 ? 0 : bwt_sample(k);
+
+			k = LF(k);
+
+		}
+
+		auto t = triple(range, j, k);
+
+		assert(t == old_count_and_get_occ(P));
+
+		return t;
 	}
 
 	/*


### PR DESCRIPTION
Hi,

I was poking around the code and found that the loop within the ``count_and_get_occ`` can be optimized by reducing the number of times the bwt is sampled. If my understanding is correct, the bwt-sample methods are called every iteration in order to track a single occurence's position within the current range. Once the range becomes unary, ``j`` is decremented instead because at this point we know we are going "back" one position at a time.

However, instead of sampling the bwt every single iteration, we can just do it just once overall as soon as one of these two cases are met:

-  when  we transition from a non-unary range to a unary range
-  when we determine the final range and find that it is still non-unary 

So the only changes that are required are an additional conditional within the loop to restrict the number of times the bwt is sampled, and a conditional after the loop for dealing with the second case. 

I did some rudimentary comparison tests, and the number of rank/select calls is drastically reduced, especially with queries that occur more than once in the index. The code also experiences a 1.5-2x speedup.

Please let me know if you have questions/concerns or if there's anything more to add.

Thanks

Taher Mun
tmun1@jhu.edu
Langmead Lab
Johns Hopkins University